### PR TITLE
feat: add card component and complete pillars & channels sections

### DIFF
--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -102,7 +102,6 @@ body {
       1px -1px 0 #000,
       -1px 1px 0 #000,
       1px 1px 0 #000,
-      /* Drop shadow effect in your secondary color */ 4px 4px 0 var(--shadow-color-secondary),
       5px 5px 0 var(--shadow-color-secondary);
   }
 }

--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -31,6 +31,13 @@ body {
     background-color: var(--color-blue-900);
   }
 
+  .bg-gradient-2 {
+    background: linear-gradient(160deg, #f495c0 0%, #f8b78e 38%, #f299a5 68%, #b57edc 100%);
+  }
+  .bg-gradient-3 {
+    background: linear-gradient(225deg, #a3eab7 0%, #7be0c3 38%, #65d4d6 68%, #6cc3f0 100%);
+  }
+
   .text-body {
     font-family: var(--font-family-serif);
     font-weight: var(--font-weight-medium);
@@ -44,6 +51,7 @@ body {
     font-size: var(--font-size-md);
     line-height: var(--line-height-normal);
     letter-spacing: var(--letter-spacing-normal);
+    color: var(--color-black);
   }
 
   .text-card-header {
@@ -51,6 +59,14 @@ body {
     font-family: var(--font-family-serif);
     font-size: var(--font-size-xl);
     font-weight: var(--font-weight-bold);
+    color: var(--color-black);
+  }
+
+  .card-shadow {
+    box-shadow:
+      0px 2px 0 #2e2e2e,
+      8px 8px 0 #2e2e2e,
+      8px 8px 15px rgba(0, 0, 0, 0.25);
   }
 
   .section-heading-primary {
@@ -68,10 +84,25 @@ body {
     /* used for following sections: pillar, channels  */
     font-family: var(--font-family-heading-primary);
     font-size: var(--font-size-header);
-    font-weight: normal;
-    line-height: var(--line-height-normal);
+    font-weight: bold;
     letter-spacing: var(--letter-spacing-wide);
-    text-shadow: 2px 2px 0 var(--shadow-color-secondary);
-    -webkit-text-stroke: var(--stroke-width-thick) #000;
+    color: white;
+
+    text-shadow:
+      /* Thicker black outline by stacking multiple offsets */
+      -3px -3px 0 #000,
+      3px -3px 0 #000,
+      -3px 3px 0 #000,
+      3px 3px 0 #000,
+      -2px -2px 0 #000,
+      2px -2px 0 #000,
+      -2px 2px 0 #000,
+      2px 2px 0 #000,
+      -1px -1px 0 #000,
+      1px -1px 0 #000,
+      -1px 1px 0 #000,
+      1px 1px 0 #000,
+      /* Drop shadow effect in your secondary color */ 4px 4px 0 var(--shadow-color-secondary),
+      5px 5px 0 var(--shadow-color-secondary);
   }
 }

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -3,8 +3,33 @@ import copy from '../../content/copy.json'
 import Container from '../layout/container/Container'
 import Section from '../layout/section/Section'
 import Layout from '../../layouts/Layout'
+import Card from '../layout/card/Card'
 
 function App() {
+  // Common props for pillar cards to reduce repetition
+  const pillarCardProps = {
+    className: 'w-72 h-112',
+    barStyle: 'dotsRight' as const,
+    align: 'left' as const,
+  }
+
+  // Configuration for pillar cards
+  const pillarCards = [
+    { variant: 'mint' as const, key: 'findingCollaborators' as const },
+    { variant: 'butter' as const, key: 'buildingCommunity' as const },
+    { variant: 'ice' as const, key: 'fosteringResourceSharing' as const },
+  ]
+
+  // Configuration for channel cards
+  const channelCards = [
+    { variant: 'lilac' as const, key: 'appliedSocialMedia' as const },
+    { variant: 'sand' as const, key: 'artsAndCulture' as const },
+    { variant: 'apricot' as const, key: 'civicTech' as const },
+    { variant: 'sky' as const, key: 'journalism' as const },
+    { variant: 'grass' as const, key: 'research' as const },
+    { variant: 'coral' as const, key: 'responsibleAI' as const },
+  ]
+
   return (
     <Layout>
       {/* Hero Section */}
@@ -26,6 +51,19 @@ function App() {
       <Section variant="gradient-2">
         <Container>
           <h1 className="section-heading-secondary">{copy.pillars.title}</h1>
+
+          <div className="mt-16 grid gap-20 md:grid-cols-3 justify-center">
+            {pillarCards.map(({ variant, key }) => (
+              <Card
+                key={key}
+                {...pillarCardProps}
+                variant={variant}
+                title={copy.pillars.cards[key].title}
+              >
+                {copy.pillars.cards[key].description}
+              </Card>
+            ))}
+          </div>
         </Container>
       </Section>
 
@@ -41,7 +79,15 @@ function App() {
       <Section variant="gradient-3">
         <Container>
           <h1 className="section-heading-secondary">{copy.channels.title}</h1>
-          <p className="text-body">{copy.channels.body}</p>
+          <p className="text-body text-black mt-16">{copy.channels.body}</p>
+
+          <div className="mt-16 grid md:grid-cols-2 gap-x-20 gap-y-16">
+            {channelCards.map(({ variant, key }) => (
+              <Card key={key} variant={variant} title={copy.channels.list[key].title}>
+                {copy.channels.list[key].description}
+              </Card>
+            ))}
+          </div>
         </Container>
       </Section>
 

--- a/src/components/layout/card/Card.tsx
+++ b/src/components/layout/card/Card.tsx
@@ -1,0 +1,185 @@
+import React from 'react'
+
+type Variant = 'mint' | 'butter' | 'ice' | 'lilac' | 'sand' | 'apricot' | 'sky' | 'grass' | 'coral'
+
+const THEME: Record<Variant, { body: string; bar: string; dots: string[] }> = {
+  mint: {
+    body: 'var(--card-mint-body)',
+    bar: 'var(--card-mint-bar)',
+    dots: [
+      'var(--dot-pillars-collaborators-1)',
+      'var(--dot-pillars-collaborators-2)',
+      'var(--dot-pillars-collaborators-3)',
+    ],
+  },
+  butter: {
+    body: 'var(--card-butter-body)',
+    bar: 'var(--card-butter-bar)',
+    dots: [
+      'var(--dot-pillars-community-1)',
+      'var(--dot-pillars-community-2)',
+      'var(--dot-pillars-community-3)',
+    ],
+  },
+  ice: {
+    body: 'var(--card-ice-body)',
+    bar: 'var(--card-ice-bar)',
+    dots: [
+      'var(--dot-pillars-resource-sharing-1)',
+      'var(--dot-pillars-resource-sharing-2)',
+      'var(--dot-pillars-resource-sharing-3)',
+    ],
+  },
+  lilac: {
+    body: 'var(--card-lilac-body)',
+    bar: 'var(--card-lilac-bar)',
+    dots: ['var(--dot-channels-1)', 'var(--dot-channels-2)', 'var(--dot-channels-3)'],
+  },
+  sand: {
+    body: 'var(--card-sand-body)',
+    bar: 'var(--card-sand-bar)',
+    dots: ['var(--dot-channels-1)', 'var(--dot-channels-2)', 'var(--dot-channels-3)'],
+  },
+  apricot: {
+    body: 'var(--card-apricot-body)',
+    bar: 'var(--card-apricot-bar)',
+    dots: ['var(--dot-channels-1)', 'var(--dot-channels-2)', 'var(--dot-channels-3)'],
+  },
+  sky: {
+    body: 'var(--card-sky-body)',
+    bar: 'var(--card-sky-bar)',
+    dots: ['var(--dot-channels-1)', 'var(--dot-channels-2)', 'var(--dot-channels-3)'],
+  },
+  grass: {
+    body: 'var(--card-grass-body)',
+    bar: 'var(--card-grass-bar)',
+    dots: ['var(--dot-channels-1)', 'var(--dot-channels-2)', 'var(--dot-channels-3)'],
+  },
+  coral: {
+    body: 'var(--card-coral-body)',
+    bar: 'var(--card-coral-bar)',
+    dots: ['var(--dot-channels-1)', 'var(--dot-channels-2)', 'var(--dot-channels-3)'],
+  },
+}
+
+const BORDER_RADIUS = 28
+const TOP_BAR_BORDER_RADIUS = 24
+
+/**
+ * Card component with themed styling and customizable layout options
+ * @param title - The card title displayed in the header
+ * @param children - The card content
+ * @param className - Additional CSS classes to apply
+ * @param variant - Theme variant for colors
+ * @param barStyle - Style of the top bar ('full' with controls or 'dotsRight' with only dots)
+ * @param align - Text alignment for content ('left' or 'center')
+ */
+type Props = {
+  title: string
+  children: React.ReactNode
+  className?: string
+  variant?: Variant
+  barStyle?: 'full' | 'dotsRight'
+  align?: 'left' | 'center'
+}
+
+// Helper component for rendering dots
+const Dots = ({ dots }: { dots: string[] }) => (
+  <div className="flex gap-2">
+    {dots.map((dot, i) => (
+      <span
+        key={i}
+        className="w-4 h-4 rounded-full border-2 border-black/70"
+        style={{ backgroundColor: dot }}
+      />
+    ))}
+  </div>
+)
+
+// Helper component for window controls
+const WindowControls = ({ bodyColor }: { bodyColor: string }) => (
+  <div className="flex items-center gap-4 opacity-80">
+    {/* minus */}
+    <div className="w-5 h-[3px] bg-black" />
+
+    {/* stacked windows */}
+    <div className="relative w-6 h-5">
+      {/* back box */}
+      <div
+        className="absolute border-[3px] border-black"
+        style={{
+          backgroundColor: bodyColor,
+          width: '23.27px',
+          height: '18.18px',
+          left: '5.82px',
+          top: '0px',
+        }}
+      />
+      {/* front box */}
+      <div
+        className="absolute border-[3px] border-black"
+        style={{
+          backgroundColor: bodyColor,
+          width: '23.27px',
+          height: '18.18px',
+          left: '0px',
+          top: '5.82px',
+        }}
+      />
+    </div>
+
+    {/* x */}
+    <div className="relative w-4 h-4">
+      <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[20px] h-[3px] bg-black rotate-45" />
+      <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[20px] h-[3px] bg-black -rotate-45" />
+    </div>
+  </div>
+)
+
+export default function Card({
+  title,
+  children,
+  className = '',
+  variant = 'mint',
+  barStyle = 'full',
+  align = 'center',
+}: Props) {
+  const v = THEME[variant]
+
+  return (
+    <div
+      style={{ backgroundColor: v.body }}
+      className={`relative rounded-[${BORDER_RADIUS}px] border-2 border-black/40 card-shadow ${className}`}
+    >
+      {/* Top bar */}
+      <div
+        style={{ backgroundColor: v.bar }}
+        className={`h-10 rounded-t-[${TOP_BAR_BORDER_RADIUS}px] border-b-2 border-black/40 ${
+          barStyle === 'dotsRight'
+            ? 'flex items-center justify-end px-4'
+            : 'flex items-center justify-between px-4'
+        }`}
+      >
+        {barStyle === 'full' ? (
+          <>
+            <Dots dots={v.dots} />
+            <WindowControls bodyColor={v.body} />
+          </>
+        ) : (
+          <Dots dots={v.dots} />
+        )}
+      </div>
+
+      {/* Content */}
+      <div className={`p-6 md:p-8 ${align === 'left' ? 'text-left' : 'text-center'}`}>
+        <h3 className="text-card-header mb-3 uppercase">{title}</h3>
+        <div className="text-card">{children}</div>
+      </div>
+
+      {/* outer ring */}
+      <div
+        className={`pointer-events-none absolute inset-0 rounded-[${BORDER_RADIUS}px] shadow-[0_0_0_4px_rgba(0,0,0,0.25)]`}
+      />
+    </div>
+  )
+}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -9,6 +9,8 @@
 
   --color-orange-500: #ffd09b;
 
+  --color-black: #000000;
+
   --color-neutral-50: #fafafa;
   --color-neutral-100: #f5f5f5;
   --color-neutral-200: #e5e5e5;
@@ -74,10 +76,55 @@
 
   /* Stroke widths */
   --stroke-width-thin: 0.5px;
-  --stroke-width-thick: 1px;
+  --stroke-width-thick: 2px;
 
   /* Layout */
   --max-width-sm: 768px;
   --max-width-md: 960px;
   --max-width-lg: 1120px;
+
+  /* Pillars */
+  --card-mint-body: #d7ffd7;
+  --card-mint-bar: #fc4e54;
+
+  --card-butter-body: #fff2b0;
+  --card-butter-bar: #a181ff;
+
+  --card-ice-body: #cef2ff;
+  --card-ice-bar: #ffa32f;
+
+  --dot-pillars-collaborators-1: #31f773;
+  --dot-pillars-collaborators-2: #dcffb0;
+  --dot-pillars-collaborators-3: #dcffb0;
+
+  --dot-pillars-community-1: #dcffb0;
+  --dot-pillars-community-2: #ffd117;
+  --dot-pillars-community-3: #dcffb0;
+
+  --dot-pillars-resource-sharing-1: #dcffb0;
+  --dot-pillars-resource-sharing-2: #dcffb0;
+  --dot-pillars-resource-sharing-3: #43ceff;
+
+  /* Channels */
+  --card-lilac-body: #e8dffe;
+  --card-lilac-bar: #9471ff;
+
+  --card-sand-body: #fcf3c8;
+  --card-sand-bar: #fed42f;
+
+  --card-apricot-body: #ffd3a2;
+  --card-apricot-bar: #e9a27a;
+
+  --card-sky-body: #cef2ff;
+  --card-sky-bar: #65befc;
+
+  --card-grass-body: #d7ffd7;
+  --card-grass-bar: #58d16e;
+
+  --card-coral-body: #ffc8b6;
+  --card-coral-bar: #fc4e54;
+
+  --dot-channels-1: #e9a27a;
+  --dot-channels-2: #ffd3a2;
+  --dot-channels-3: #a3d0cb;
 }


### PR DESCRIPTION
### Summary
This PR introduces the new Card component and applies it to the Pillars and Channels sections, completing their layout and styling as per the Figma design.

### Changes
Implemented reusable Card component with customizable variants, bar styles, and dot colors.

Completed Pillars section:
- Adjusted heading with more accurate stroke and shadow styling.
- Configured card sizing, spacing, and shadows.
- Applied background gradient.

Completed Channels section:
- Updated heading and body text with proper spacing.
- Styled cards with updated bar controls (minus, stacked windows, X).
- Applied background gradient.

Closes #18. Closes #23. Closes #21.

Attached screenshots/videos of the completed sections.
<img width="1440" height="739" alt="Screen Shot 2025-08-10 at 11 13 13 AM" src="https://github.com/user-attachments/assets/cb5d7913-e52e-4e40-a0b2-9bf6777dfb9a" />

https://github.com/user-attachments/assets/2a57e8d2-f20d-487f-beaa-99a46c8d927b

