### PR TITLE
Fix/Add correct vite base path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,4 +5,6 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  // Change to / once setup with custom domain
+  base: '/prosocialtech-website/',
 })


### PR DESCRIPTION
  Add base: '/prosocialtech-website/' to vite.config.ts to fix 404 errors on deployed assets.

  Issue: GitHub Pages serves from /prosocialtech-website/ but Vite defaults to /, causing asset paths to 404.

  Solution: Configure Vite base path to match GitHub Pages URL structure.