### PR TITLE
Embed community Google Calendar month view on site

### DIFF
--- a/src/components/app/App.tsx
+++ b/src/components/app/App.tsx
@@ -37,7 +37,7 @@ function App() {
     <Layout>
       <Hero data={copy.hero} />
 
-      {/* About Section */}
+      {/* About & Upcoming Events Section */}
       <Section variant="dark">
         <Container size="sm" className="text-left space-y-8">
           <h2 className="section-heading-primary">{copy.about.title}</h2>
@@ -48,25 +48,50 @@ function App() {
               </p>
             ))}
           </div>
-          {copy.about.more && (
-            <div className="space-y-6">
-              <h2 className="section-heading-primary">{copy.about.more.title}</h2>
-              <div className="space-y-4">
-                {copy.about.more.body.split('\n\n').map((paragraph, index) => (
-                  <p key={index} className="text-body">
-                    {paragraph}
-                  </p>
-                ))}
-              </div>
-              {copy.about.more.image?.src && (
-                <img
-                  src={copy.about.more.image.src}
-                  alt={copy.about.more.image.alt || ''}
-                  className="w-full max-w-4xl rounded-md border border-neutral-800"
-                />
-              )}
+          <div className="space-y-6">
+            <h2 className="section-heading-primary">{copy.upcoming.title}</h2>
+            <p className="text-body">
+              {copy.upcoming.body1.split('Community Calendar')[0]}
+              <a
+                href={copy.upcoming.links.calendar.href}
+                target="_blank"
+                rel="noreferrer"
+                className="underline"
+              >
+                {copy.upcoming.links.calendar.label}
+              </a>
+              {copy.upcoming.body1.split('Community Calendar')[1]}
+            </p>
+            <div className="mt-8 overflow-hidden rounded-lg border border-white/15 bg-black/20 shadow-lg">
+              <iframe
+                title="Community calendar — month view"
+                src={copy.upcoming.links.calendar.embedSrc}
+                className="h-[min(70vh,720px)] w-full min-h-[480px] border-0"
+                loading="lazy"
+              />
             </div>
-          )}
+            <p className="text-body">
+              {copy.upcoming.body2.split('share')[0]}
+              <a
+                href={copy.upcoming.links.share.href}
+                target="_blank"
+                rel="noreferrer"
+                className="underline"
+              >
+                {copy.upcoming.links.share.label}
+              </a>
+              {copy.upcoming.body2.split('share')[1].split('submit an idea for a gathering')[0]}
+              <a
+                href={copy.upcoming.links.gathering.href}
+                target="_blank"
+                rel="noreferrer"
+                className="underline"
+              >
+                {copy.upcoming.links.gathering.label}
+              </a>
+              {copy.upcoming.body2.split('submit an idea for a gathering')[1]}
+            </p>
+          </div>
         </Container>
       </Section>
 
@@ -150,53 +175,28 @@ function App() {
         </Container>
       </Section>
 
-      {/* Upcoming Events & Footer Section */}
+      {/* About more & Footer Section */}
       <Section variant="dark">
         <Container size="md" className="text-left space-y-10">
-          <div className="space-y-6">
-            <h2 className="section-heading-primary">{copy.upcoming.title}</h2>
-            <p className="text-body">
-              {copy.upcoming.body1.split('Community Calendar')[0]}
-              <a
-                href={copy.upcoming.links.calendar.href}
-                target="_blank"
-                rel="noreferrer"
-                className="underline"
-              >
-                {copy.upcoming.links.calendar.label}
-              </a>
-              {copy.upcoming.body1.split('Community Calendar')[1]}
-            </p>
-            <div className="mt-8 overflow-hidden rounded-lg border border-white/15 bg-black/20 shadow-lg">
-              <iframe
-                title="Community calendar — month view"
-                src={copy.upcoming.links.calendar.embedSrc}
-                className="h-[min(70vh,720px)] w-full min-h-[480px] border-0"
-                loading="lazy"
-              />
+          {copy.about.more && (
+            <div className="space-y-6">
+              <h2 className="section-heading-primary">{copy.about.more.title}</h2>
+              <div className="space-y-4">
+                {copy.about.more.body.split('\n\n').map((paragraph, index) => (
+                  <p key={index} className="text-body">
+                    {paragraph}
+                  </p>
+                ))}
+              </div>
+              {copy.about.more.image?.src && (
+                <img
+                  src={copy.about.more.image.src}
+                  alt={copy.about.more.image.alt || ''}
+                  className="w-full max-w-4xl rounded-md border border-neutral-800"
+                />
+              )}
             </div>
-            <p className="text-body">
-              {copy.upcoming.body2.split('share')[0]}
-              <a
-                href={copy.upcoming.links.share.href}
-                target="_blank"
-                rel="noreferrer"
-                className="underline"
-              >
-                {copy.upcoming.links.share.label}
-              </a>
-              {copy.upcoming.body2.split('share')[1].split('submit an idea for a gathering')[0]}
-              <a
-                href={copy.upcoming.links.gathering.href}
-                target="_blank"
-                rel="noreferrer"
-                className="underline"
-              >
-                {copy.upcoming.links.gathering.label}
-              </a>
-              {copy.upcoming.body2.split('submit an idea for a gathering')[1]}
-            </p>
-          </div>
+          )}
 
           <div className="space-y-4">
             <h2 className="section-heading-primary">{copy.footer.title}</h2>

--- a/src/components/app/App.tsx
+++ b/src/components/app/App.tsx
@@ -167,6 +167,14 @@ function App() {
               </a>
               {copy.upcoming.body1.split('Community Calendar')[1]}
             </p>
+            <div className="mt-8 overflow-hidden rounded-lg border border-white/15 bg-black/20 shadow-lg">
+              <iframe
+                title="Community calendar — month view"
+                src={copy.upcoming.links.calendar.embedSrc}
+                className="h-[min(70vh,720px)] w-full min-h-[480px] border-0"
+                loading="lazy"
+              />
+            </div>
             <p className="text-body">
               {copy.upcoming.body2.split('share')[0]}
               <a

--- a/src/content/copy.json
+++ b/src/content/copy.json
@@ -145,7 +145,8 @@
     "links": {
       "calendar": {
         "label": "Community Calendar",
-        "href": "https://calendar.google.com/calendar/u/0/embed?src=f6a92086e61c0b1ff98c5b686011a7e2c055c385c0f7cc1e4f9c2fb78a311600@group.calendar.google.com&ctz=America/Los_Angeles"
+        "href": "https://calendar.google.com/calendar/u/0/embed?src=f6a92086e61c0b1ff98c5b686011a7e2c055c385c0f7cc1e4f9c2fb78a311600@group.calendar.google.com&ctz=America/Los_Angeles",
+        "embedSrc": "https://calendar.google.com/calendar/embed?src=f6a92086e61c0b1ff98c5b686011a7e2c055c385c0f7cc1e4f9c2fb78a311600%40group.calendar.google.com&ctz=America%2FLos_Angeles&mode=MONTH"
       },
       "share": {
         "label": "share",


### PR DESCRIPTION
Allow users to see monthly preview of upcoming events in PTC calendar, re-ordered upcoming events and "what is prosocial technology"


https://github.com/user-attachments/assets/e941b82f-20fe-4eae-8220-84f46abb3660

<img width="1185" height="804" alt="Screen Shot 2026-04-02 at 6 21 25 PM" src="https://github.com/user-attachments/assets/8cacbf4c-d034-4762-a1d4-789add95b3f0" />

